### PR TITLE
(docs): remove bintray references from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ ext {
 
 sourceCompatibility = 1.8
 
-repositories {
-    jcenter()
-}
-
 dependencies {
     compile "com.commercetools.rmf:raml-model:${rmfVersion}"
 }
@@ -38,12 +34,3 @@ To start the RMF generator using docker use the following command
 ```
 docker run --rm -v<RAML-definition-directory>:/api -v<output-directory>:/out vrapio/rmf-generator -l postman /api/update-actions.raml
 ```
-
-### Bintray upload
-
-Set environment variables BINTRAY_USER and BINTRAY_KEY to your bintray credentials.
-Run gradle with
-```
-./gradlew clean build bintrayUpload --info
-```
-to upload the artifacts to the `rmf` repository in your bintray project.


### PR DESCRIPTION
not needed anymore since rmf is now in maven central